### PR TITLE
Prevent hidden outline on focussed input

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,6 +42,10 @@ a:hover {
     box-shadow: inset 0px 0px 1px #000;
 }
 
+#puzzle input:focus-visible {
+    position: relative;
+}
+
 #puzzle input.even {
     background-color: rgba(255,255,255,0.6);
 }


### PR DESCRIPTION
Add `position: relative` to focussed inputs to prevent that their outline is hidden behind the next element.