### PR TITLE
Add a `[1-9]` pattern to input

### DIFF
--- a/sudoku.js
+++ b/sudoku.js
@@ -24,6 +24,8 @@ const init = () => {
             let field = document.createElement( 'input' );
             field.setAttribute( 'id', 'field-' + x + y );
             field.setAttribute( 'maxlength', 1 );
+            field.setAttribute('pattern' , '[1-9]');
+            field.setAttribute('inputmode' , 'numeric');
             field.setAttribute( 'value', '' );
             let cssClass = ( Math.floor( x / 3 ) + Math.floor( y / 3 ) ) % 2 == 1 ? 'odd' : 'even';
             field.setAttribute( 'class', cssClass );


### PR DESCRIPTION
This should bring up the numeric keyboard on touch devices.

I played around with it on mobile and noticed this. This solution does not support Safari, however. I think the `pattern` attribute needs to be set to `\d*` to change this (but it'll then also allow `0`). One option would be to keep `inputmode="numeric"` to support most browsers and `pattern="\d*"` to show the keypad on Safari as well, the other option would be to ignore Safari support. If you have an opinion and consider merging it, I'll gladly update the PR to your decision, @roytanck.